### PR TITLE
[Hotfix] Info.plist 마이그레이션

### DIFF
--- a/C3-4T2D.xcodeproj/project.pbxproj
+++ b/C3-4T2D.xcodeproj/project.pbxproj
@@ -10,9 +10,22 @@
 		232927192DE6A6ED00FAC3B8 /* C3-4T2D.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "C3-4T2D.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		C751FFAA2DEFF31C00DC99E9 /* Exceptions for "C3-4T2D" folder in "C3-4T2D" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = 232927182DE6A6ED00FAC3B8 /* C3-4T2D */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		2329271B2DE6A6ED00FAC3B8 /* C3-4T2D */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				C751FFAA2DEFF31C00DC99E9 /* Exceptions for "C3-4T2D" folder in "C3-4T2D" target */,
+			);
 			path = "C3-4T2D";
 			sourceTree = "<group>";
 		};
@@ -253,9 +266,10 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 9A96KXU385;
+				DEVELOPMENT_TEAM = RP5GZ99V95;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "$(SRCROOT)/C3-4T2D/Info.plist";
 				INFOPLIST_KEY_NSCameraUsageDescription = "작품을 촬영하여 기록하기 위해 카메라 접근이 필요합니다.";
 				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "편집된 작품을 사진 앨범에 저장하기 위해 접근 권한이 필요합니다.";
 				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "작품 사진을 앨범에서 불러와 저장하고 기록하기 위해 사진 라이브러리 접근이 필요합니다.";
@@ -284,9 +298,10 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 9A96KXU385;
+				DEVELOPMENT_TEAM = RP5GZ99V95;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "$(SRCROOT)/C3-4T2D/Info.plist";
 				INFOPLIST_KEY_NSCameraUsageDescription = "작품을 촬영하여 기록하기 위해 카메라 접근이 필요합니다.";
 				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "편집된 작품을 사진 앨범에 저장하기 위해 접근 권한이 필요합니다.";
 				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "작품 사진을 앨범에서 불러와 저장하고 기록하기 위해 사진 라이브러리 접근이 필요합니다.";

--- a/C3-4T2D/Info.plist
+++ b/C3-4T2D/Info.plist
@@ -1,8 +1,54 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+"http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>UIUserInterfaceStyle</key>
-	<string>Light</string>
+    <key>CFBundleIdentifier</key>
+    <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+    <key>CFBundleName</key>
+    <string>$(PRODUCT_NAME)</string>
+    <key>CFBundleVersion</key>
+    <string>$(CURRENT_PROJECT_VERSION)</string>
+    <key>CFBundleShortVersionString</key>
+    <string>$(MARKETING_VERSION)</string>
+    <key>CFBundleExecutable</key>
+    <string>$(EXECUTABLE_NAME)</string>
+    <key>CFBundlePackageType</key>
+    <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>$(DEVELOPMENT_LANGUAGE)</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>UIUserInterfaceStyle</key>
+    <string>Light</string>
+    <key>UIApplicationSupportsIndirectInputEvents</key>
+    <true/>
+    <key>UIApplicationRequiresFullScreen</key>
+    <true/>
+    <key>UILaunchScreen</key>
+    <dict/>
+    <key>UISupportedInterfaceOrientations</key>
+    <array>
+        <string>UIInterfaceOrientationPortrait</string>
+        <string>UIInterfaceOrientationLandscapeLeft</string>
+        <string>UIInterfaceOrientationLandscapeRight</string>
+    </array>
+    <key>UISupportedInterfaceOrientations~ipad</key>
+    <array>
+        <string>UIInterfaceOrientationPortrait</string>
+        <string>UIInterfaceOrientationLandscapeLeft</string>
+        <string>UIInterfaceOrientationLandscapeRight</string>
+    </array>
+    <key>UIApplicationSceneManifest</key>
+    <dict>
+        <key>UIApplicationSupportsMultipleScenes</key>
+        <false/>
+    </dict>
+    <key>NSCameraUsageDescription</key>
+    <string>작품을 촬영하여 기록하기 위해 카메라 접근이 필요합니다.</string>
+    <key>NSPhotoLibraryUsageDescription</key>
+    <string>작품 사진을 앨범에서 불러와 저장하고 기록하기 위해 사진 라이브러리 접근이 필요</string>
+    <key>NSPhotoLibraryAddUsageDescription</key>
+    <string>편집된 작품을 사진 앨범에 저장하기 위해 접근 권한이 필요합니다.</string>
 </dict>
 </plist>


### PR DESCRIPTION
## 관련 이슈
- Closes #41

## 작업 내용
- 기존의 내장된 info가 아닌 명시적 Info.plist 파일로 빌드타겟을 변경하여 권한 편집이 용이하게 하였음.


## 체크리스트
- [x] 빌드 에러 없음
- [x] 기본 동작 테스트 완료
- [x] 코드 리뷰 준비 완료
