### PR TITLE
[Fix] 스크롤 시 키보드가 닫히지 않는 문제 해결

### DIFF
--- a/C3-4T2D/View/Create/CreateView.swift
+++ b/C3-4T2D/View/Create/CreateView.swift
@@ -61,7 +61,7 @@ struct CreateView: View {
                 }
                 .padding(.horizontal, 20)
             }
-            .scrollDismissesKeyboard(.interactively)
+            .scrollDismissesKeyboard(.immediately)
         }
         .fullScreenCover(isPresented: $isPresentingCamera) {
             ZStack {


### PR DESCRIPTION
## 관련 이슈
- Closes #49 

## 작업 내용
- 스크롤 시작과 동시에 키보드가 즉시 닫히도록 수정
- 키보드가 화면에 계속 남아있는 UI 버그 해결

## 변경사항
- scrollDismissesKeyboard 모드를 .interactively에서 .immediately로 변경

## 체크리스트
- [x] 빌드 에러 없음
- [x] 기본 동작 테스트 완료
- [x] 코드 리뷰 준비 완료
