### PR TITLE
[Fix] 온보딩 네비게이션 스택 문제 조건부 렌더링으로 해결

### DIFF
--- a/C3-4T2D/View/OnboardingView/OnboardingView.swift
+++ b/C3-4T2D/View/OnboardingView/OnboardingView.swift
@@ -70,7 +70,7 @@ struct OnboardingView: View {
         )
         do {
             try modelContext.save()
-            router.navigate(to: .mainView)
+            router.navigateToRoot()
         } catch {
             print("Error saving user: \(error)")
         }


### PR DESCRIPTION
## 관련 이슈
- Closes #71 

## 작업 내용
- NavigationStack 내부에서 users 상태에 따라 OnboardingView와 MainView를 조건부로 렌더링하도록 수정
- 기존의 router.navigateToRoot() 호출을 제거하고, 상태 기반 전환으로 네비게이션 스택에 OnboardingView가 남지 않도록 개선

## 변경사항
- users.isEmpty 조건에 따라 루트 뷰가 자동으로 교체되도록 구현

## 스크린샷 (UI 변경 시)
### Before

https://github.com/user-attachments/assets/5e0a46c7-665e-4e6d-b31d-9d734bd38c36


### After
- **users 상태 변경 시(users 생성) 자동으로 MainView로 전환되어 OnboardingView가 스택에 남지 않음**

https://github.com/user-attachments/assets/18f391af-9e19-4637-87d9-ce6f04554681


## 체크리스트
- [x] 빌드 에러 없음
- [x] 기본 동작 테스트 완료
- [x] 코드 리뷰 준비 완료
