### PR TITLE
[Feature] confirmationDialog내 '취소' 버튼 명시화

### DIFF
--- a/C3-4T2D/View/MainView/MainView.swift
+++ b/C3-4T2D/View/MainView/MainView.swift
@@ -200,11 +200,14 @@ struct MainView: View {
         .confirmationDialog("진행중인 과정", isPresented: $showActionSheet, titleVisibility: .visible) {
             Button("바로 촬영하기") { showCamera = true }
             Button("과정 기록하기") { showCreate = true }
+            Button("취소", role: .cancel) {}
         }
+        
         .confirmationDialog("프로젝트 정렬", isPresented: $showSortSheet, titleVisibility: .visible) {
             ForEach(SortOrder.allCases, id: \.self) { order in
                 Button(order.rawValue) { sortOrder = order }
             }
+            Button("취소", role: .cancel) {}
         }
     }
 }


### PR DESCRIPTION
## 관련 이슈
- Closes #85

## 작업 내용
- confirmationDialog 내에 명시되어있지 않았던 '취소' 버튼을 추가하고 .cancel Role 부여

## 스크린샷 (UI 변경 시)
- 
<img width="393" alt="스크린샷 2025-06-06 오후 11 41 35" src="https://github.com/user-attachments/assets/9e2405a3-c28a-418b-ba1d-d01267dc44ed" />
<img width="359" alt="스크린샷 2025-06-06 오후 11 41 30" src="https://github.com/user-attachments/assets/b0a46152-c1ad-4f53-bda1-b12a0c592339" />


## 체크리스트
- [x] 빌드 에러 없음
- [x] 기본 동작 테스트 완료
- [x] 코드 리뷰 준비 완료
