### PR TITLE
[Bug] PostView 네비게이션 UI 개선 및 Post 없는 상태 처리 #98

### DIFF
--- a/C3-4T2D/View/ProjectView/PostView.swift
+++ b/C3-4T2D/View/ProjectView/PostView.swift
@@ -8,6 +8,7 @@ import SwiftUI
 
 struct PostView: View {
     let post: Post
+    let project: Project
     @Environment(\.modelContext) private var modelContext
     @Environment(\.dismiss) private var dismiss
     @Environment(Router.self) private var router
@@ -23,7 +24,7 @@ struct PostView: View {
 //                    Text(stage ?? "과정 없음")
 //                        .font(.system(size: 24, weight: .bold))
 //                }
-                Text("채색(1)")
+                Text(project.projectTitle)
                     .font(.system(size: 19, weight: .bold))
                 Spacer()
                 // ... (더보기 버튼 등)

--- a/C3-4T2D/View/ProjectView/ProjectList.swift
+++ b/C3-4T2D/View/ProjectView/ProjectList.swift
@@ -25,7 +25,7 @@ struct ProjectList: View {
                     PostView(post: post,project: project)
                 }
             }
-        }.navigationTitle(project.projectTitle) // Header에 프로젝트 title 노출
+        }
     }
 }
 

--- a/C3-4T2D/View/ProjectView/ProjectList.swift
+++ b/C3-4T2D/View/ProjectView/ProjectList.swift
@@ -11,6 +11,7 @@ import SwiftUI
 struct ProjectList: View {
     let project: Project
     @Query private var posts: [Post]
+    @Environment(\.dismiss) var dismiss
 
     init(_ project: Project) {
         self.project = project
@@ -22,8 +23,15 @@ struct ProjectList: View {
         ScrollView {
             LazyVStack(spacing: 25) {
                 ForEach(posts, id: \.id) { post in
-                    PostView(post: post,project: project)
+                    PostView(post: post, project: project)
                 }
+                .navigationBarBackButtonHidden(true)
+                .navigationBarItems(leading: Button(action: {
+                    dismiss()
+                }) {
+                    Image(systemName: "chevron.left")
+                        .foregroundStyle(.black)
+                })
             }
         }
     }

--- a/C3-4T2D/View/ProjectView/ProjectList.swift
+++ b/C3-4T2D/View/ProjectView/ProjectList.swift
@@ -22,7 +22,7 @@ struct ProjectList: View {
         ScrollView {
             LazyVStack(spacing: 25) {
                 ForEach(posts, id: \.id) { post in
-                    PostView(post: post)
+                    PostView(post: post,project: project)
                 }
             }
         }.navigationTitle(project.projectTitle) // Header에 프로젝트 title 노출

--- a/C3-4T2D/View/ProjectView/ProjectList.swift
+++ b/C3-4T2D/View/ProjectView/ProjectList.swift
@@ -21,19 +21,31 @@ struct ProjectList: View {
 
     var body: some View {
         ScrollView {
-            LazyVStack(spacing: 25) {
-                ForEach(posts, id: \.id) { post in
-                    PostView(post: post, project: project)
+            if posts.isEmpty {
+                VStack(spacing: 10) {
+                    Image(systemName: "tray")
+                        .font(.system(size: 50))
+                        .foregroundStyle(.gray)
+                    Text("아직 작성된 포스트가 없어요")
+                        .font(.subheadline)
+                        .foregroundStyle(.gray)
                 }
-                .navigationBarBackButtonHidden(true)
-                .navigationBarItems(leading: Button(action: {
-                    dismiss()
-                }) {
-                    Image(systemName: "chevron.left")
-                        .foregroundStyle(.black)
-                })
+                .padding(.top, 100)
+            } else {
+                LazyVStack(spacing: 25) {
+                    ForEach(posts, id: \.id) { post in
+                        PostView(post: post, project: project)
+                    }
+                }
             }
         }
+        .navigationBarBackButtonHidden(true)
+        .navigationBarItems(leading: Button(action: {
+            dismiss()
+        }) {
+            Image(systemName: "chevron.left")
+                .foregroundStyle(.black)
+        })
     }
 }
 


### PR DESCRIPTION
## 관련 이슈
- Closes #98

## 작업 내용
- 네비게이션바에 프로젝트 타이틀 제거
- 기본 네비게이션 Back 버튼 제거
- 프로젝트에 연결된 포스트가 없을 경우, 안내 문구 및 아이콘 표시

## 변경사항
- PostView navigationTitle 제거
- navigationBarBackButtonHidden(true)을 사용해 시스템 Back 버튼 제거
- posts.isEmpty 조건 분기로 “작성된 포스트가 없습니다” 문구 표시


## 스크린샷 (UI 변경 시)
### Before 스크린샷
<img width="333" alt="Image" src="https://github.com/user-attachments/assets/b60b62df-dce6-430e-94a7-3670670b0335" />


### After 스크린샷
<img width="333" alt="Image" src="https://github.com/user-attachments/assets/abaac077-34b0-4ce7-9f43-e58292929181" />

<img width="333" alt="Image" src="https://github.com/user-attachments/assets/dc5d6034-4b7e-42ae-82ba-4e0f0eff2f93" />



## 체크리스트
- [x] 빌드 에러 없음
- [x] 기본 동작 테스트 완료
- [x] 코드 리뷰 준비 완료
