### PR TITLE
[Feature] 프로젝트 진행단계 저장기능 구현  #80

### DIFF
--- a/C3-4T2D/Model/Project/Post.swift
+++ b/C3-4T2D/Model/Project/Post.swift
@@ -18,17 +18,19 @@ final class Post {
     var order: Int
     var createdAt: Date
     var comments: [Comment] = []
+    var postStage: ProcessStage
 
     // Project와 연결된 부분
     var project: Project?
 
-    init(postImageUrl: String? = nil, memo: String? = nil, order: Int = 0, project: Project? = nil, createdAt: Date = Date()) {
+    init(postImageUrl: String? = nil, memo: String? = nil, order: Int = 0, project: Project? = nil, createdAt: Date = Date(), postStage: ProcessStage = .idea) {
         self.id = UUID()
         self.postImageUrl = postImageUrl
         self.memo = memo
         self.order = order
         self.project = project
         self.createdAt = createdAt
+        self.postStage = postStage
     }
 
     // 포스트 삭제 시 프로젝트도 0개면 삭제

--- a/C3-4T2D/Model/Project/Post.swift
+++ b/C3-4T2D/Model/Project/Post.swift
@@ -12,13 +12,14 @@ import SwiftUI
 @Model
 final class Post {
     @Attribute(.unique) var id: UUID
+    
     var postImageUrl: String?
     var memo: String?
     // 사용자 지정 순서 -> 유저가 혹여나 순서를 잘못올렸을때 사용 (아직 활용 X )
     var order: Int
     var createdAt: Date
     var comments: [Comment] = []
-    var postStage: ProcessStage
+    @Attribute var postStage: ProcessStage
 
     // Project와 연결된 부분
     var project: Project?

--- a/C3-4T2D/Model/SwiftDataManager.swift
+++ b/C3-4T2D/Model/SwiftDataManager.swift
@@ -18,8 +18,8 @@ enum SwiftDataManager {
     }
 
     /// 프로젝트에 포스트 추가
-    static func addPost(to project: Project, context: ModelContext, imageUrl: String? = nil, memo: String? = nil) {
-        let post = Post(postImageUrl: imageUrl, memo: memo, project: project) // project 무조건 필수
+    static func addPost(to project: Project, context: ModelContext, imageUrl: String? = nil, memo: String? = nil, postStage: ProcessStage = .idea) {
+        let post = Post(postImageUrl: imageUrl, memo: memo, project: project, postStage: postStage) // project 무조건 필수
         project.postList.append(post)
         context.insert(post)
     }

--- a/C3-4T2D/View/Create/CreateView.swift
+++ b/C3-4T2D/View/Create/CreateView.swift
@@ -98,6 +98,8 @@ struct CreateView: View {
                             editingPost.project = project
                             editingPost.createdAt = selectedDate
                             editingPost.postImageUrl = imageUrl
+                            editingPost.postStage = selectedStage
+                            
                         } else {
                             // 신규 작성
                             let post = Post(
@@ -105,6 +107,7 @@ struct CreateView: View {
                                 memo: descriptionText,
                                 project: project,
                                 createdAt: selectedDate
+                                postStage: selectedStage
                             )
                             context.insert(post)
                         }

--- a/C3-4T2D/View/Create/CreateView.swift
+++ b/C3-4T2D/View/Create/CreateView.swift
@@ -51,6 +51,8 @@ struct CreateView: View {
         _selectedProject = State(initialValue: editingPost?.project ?? initialProject)
         _descriptionText = State(initialValue: editingPost?.memo ?? initialMemo)
         _selectedDate = State(initialValue: editingPost?.createdAt ?? initialDate)
+        // 수정: editingPost의 postStage를 초기값으로 설정
+        _selectedStage = State(initialValue: editingPost?.postStage ?? .idea)
     }
 
     var body: some View {
@@ -106,7 +108,7 @@ struct CreateView: View {
                                 postImageUrl: imageUrl,
                                 memo: descriptionText,
                                 project: project,
-                                createdAt: selectedDate
+                                createdAt: selectedDate,
                                 postStage: selectedStage
                             )
                             context.insert(post)

--- a/C3-4T2D/View/Create/Local/ProcessStage.swift
+++ b/C3-4T2D/View/Create/Local/ProcessStage.swift
@@ -5,7 +5,7 @@
 //  Created by Hwnag Seyeon on 6/2/25.
 //
 
-enum ProcessStage: String, CaseIterable, Identifiable {
+enum ProcessStage: String, CaseIterable, Identifiable, Codable {
     case idea = "아이디어"
     case sketch = "스케치"
     case coloring = "채색"

--- a/C3-4T2D/View/MainView/MainView.swift
+++ b/C3-4T2D/View/MainView/MainView.swift
@@ -240,8 +240,8 @@ struct RoundedCorner: Shape {
         return Path(path.cgPath)
     }
 }
-
-#Preview {
-    MainView()
-        .environment(Router())
-}
+//
+//#Preview {
+//    MainView()
+//        .environment(Router())
+//}

--- a/C3-4T2D/View/ProjectView/PostView.swift
+++ b/C3-4T2D/View/ProjectView/PostView.swift
@@ -81,7 +81,7 @@ struct PostView: View {
                 try? modelContext.save()
             }) {
                 CommentModal(comments: $comments)
-                    .presentationDetents([.medium, .large])
+                    .presentationDetents([.medium])
                     .presentationDragIndicator(.visible)
             }
 

--- a/C3-4T2D/View/ProjectView/PostView.swift
+++ b/C3-4T2D/View/ProjectView/PostView.swift
@@ -17,21 +17,24 @@ struct PostView: View {
     @State private var editImage: UIImage? = nil
     @State private var showCommentModal = false
     @State private var comments: [Comment] = []
-    
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
             // 스테이지 미리 준비
             HStack(alignment: .center, spacing: 8) {
-                //프로젝트 제목
+                // 프로젝트 제목
                 Text(project.projectTitle)
                     .font(.system(size: 19, weight: .bold))
-                
-                //진행 단계
+
+                // 진행 단계
                 Text(post.postStage.rawValue)
-                    .font(.system(size: 24, weight: .bold))
-                
-                
+                    .font(.system(size: 11, weight: .medium))
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 2)
+                    .background(.prime4)
+                    .foregroundColor(.gray3)
+                    .cornerRadius(4)
+
                 Spacer()
                 // ... (더보기 버튼 등)
                 Menu {

--- a/C3-4T2D/View/ProjectView/PostView.swift
+++ b/C3-4T2D/View/ProjectView/PostView.swift
@@ -17,17 +17,21 @@ struct PostView: View {
     @State private var editImage: UIImage? = nil
     @State private var showCommentModal = false
     @State private var comments: [Comment] = []
+    
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
             // 스테이지 미리 준비
             HStack(alignment: .center, spacing: 8) {
-//                if let stage = post.stage?.rawValue {
-//                    Text(stage ?? "과정 없음")
-//                        .font(.system(size: 24, weight: .bold))
-//                }
+                //프로젝트 제목
                 Text(project.projectTitle)
                     .font(.system(size: 19, weight: .bold))
+                
+                //진행 단계
+                Text(post.postStage.rawValue)
+                    .font(.system(size: 24, weight: .bold))
+                
+                
                 Spacer()
                 // ... (더보기 버튼 등)
                 Menu {
@@ -76,15 +80,14 @@ struct PostView: View {
             }
 
             LikeCommentBar(commentCount: comments.count, onCommentTap: { showCommentModal = true })
-            .sheet(isPresented: $showCommentModal, onDismiss: {
-                post.comments = comments
-                try? modelContext.save()
-            }) {
-                CommentModal(comments: $comments)
-                    .presentationDetents([.medium])
-                    .presentationDragIndicator(.visible)
-            }
-
+                .sheet(isPresented: $showCommentModal, onDismiss: {
+                    post.comments = comments
+                    try? modelContext.save()
+                }) {
+                    CommentModal(comments: $comments)
+                        .presentationDetents([.medium])
+                        .presentationDragIndicator(.visible)
+                }
         }
         .padding(.horizontal, 20)
         .alert("정말 삭제하시겠습니까?", isPresented: $showDeleteAlert) {
@@ -117,5 +120,5 @@ struct PostView: View {
 }
 
 // #Preview {
-//    ProjectView()
+//    PostView()
 // }


### PR DESCRIPTION
## 관련 이슈
- Closes #80

## 작업 내용
- Post 모델의 postStage enum 값을 UI 상에서 시각적으로 표현하는 배지(Badge) 컴포넌트를 구현했습니다.
- 사용자가 포스트를 생성하거나 수정할 때 설정한 진행 단계를, 각 포스트 뷰 상에서 쉽게 식별할 수 있도록 표현했습니다.


## 변경사항
- Post 모델에 진행 상황을 기록하는 postStage 변수 선언
- Post가 작성되거나 생성될 때 진행 단계도 업데이트
- 상세 뷰 또는 리스트에서 postStage를 기반으로 배지 출력

## 스크린샷 (UI 변경 시)
### Before
<img width="330" alt="Image" src="https://github.com/user-attachments/assets/45910be7-6579-49ba-a4fc-e4b5a0fcb560" />


### After
<img width="330" alt="Image" src="https://github.com/user-attachments/assets/8720fe2d-1599-4bd1-9a79-2e5a4877e02e" />



## 체크리스트
- [x] 빌드 에러 없음
- [x] 기본 동작 테스트 완료
- [x] 코드 리뷰 준비 완료
